### PR TITLE
patch atftpd to support bigger file transfer via rollover

### DIFF
--- a/tftp_file.c
+++ b/tftp_file.c
@@ -618,6 +618,7 @@ int tftp_send_file(struct client_data *data)
      int convert = 0;           /* if true, do netascii convertion */
      char string[MAXLEN];
 
+     int block_number_rollover = 0;
      int prev_block_number = 0; /* needed to support netascii convertion */
      int prev_file_pos = 0;
      int temp = 0;
@@ -717,11 +718,15 @@ int tftp_send_file(struct client_data *data)
                timeout_state = S_SEND_DATA;
 
                data_size = tftp_file_read(fp, tftphdr->th_data, data->data_buffer_size - 4, block_number,
-                                          convert, &prev_block_number, &prev_file_pos, &temp);
+                                          convert, &prev_block_number, &prev_file_pos,
+                                          &block_number_rollover, &temp);
                data_size += 4;  /* need to consider tftp header */
 
                if (feof(fp))
-                    last_block = block_number;
+               {
+                   last_block = block_number;
+                   block_number_rollover = 0;
+               }
                tftp_send_data(sockfd, &sa, block_number + 1,
                               data_size, data->data_buffer);
                data->file_size += data_size;

--- a/tftp_io.c
+++ b/tftp_io.c
@@ -345,12 +345,11 @@ int tftp_file_read(FILE *fp, char *data_buffer, int data_buffer_size, int block_
      int data_size;
 
      /* In case of a rollover calculate the real block_number */
-     block_number = *block_number_rollover * 65536 + block_number;
-     if (*prev_block_number > block_number)
+     if (*prev_block_number > 0 && block_number == 0)
      {
 	  (*block_number_rollover)++;
-	  block_number = *block_number_rollover * 65536;
      }
+     block_number = *block_number_rollover * 65536 + block_number;
 
      if (!convert)
      {

--- a/tftp_io.h
+++ b/tftp_io.h
@@ -53,7 +53,7 @@ int tftp_get_packet(int sock1, int sock2, int *sock, struct sockaddr_in *sa,
                     struct sockaddr_in *from, struct sockaddr_in *to,
                     int timeout, int *size, char *data);
 int tftp_file_read(FILE *fp, char *buffer, int buffer_size, int block_number, int convert,
-                   int *prev_block_number, int *prev_file_pos, int *temp);
+                   int *prev_block_number, int *prev_file_pos, int *block_number_rollover, int *temp);
 int tftp_file_write(FILE *fp, char *data_buffer, int data_buffer_size, int block_number,
                     int data_size, int convert, int *prev_block_number, int *temp);
 #endif


### PR DESCRIPTION
Hallo,

leider ist die aktuelle Version von atftpd im OPSI auf Dateien, die kleiner sind als 65536 * (MTU -Header) beschränkt (unter 100 MB bei MTU von 1500). Gerade bei initrd Transfers (z.B. miniroot-x64.bz) stößt man recht schnell an die Grenze, wenn das Linux etwas komplexer ist. Außerdem fordert z.B. Grub nur 1024KB Blöcke via tftp an, so dass das Laden des miniroot-x64.bz fehlschlägt, weil es zu groß ist. Daher hier ein Patch, der dieses Problem umgeht.

Viele Grüße
Thomas Schlien